### PR TITLE
GearmanClient::do -> GearmanClient::doNormal

### DIFF
--- a/client.php
+++ b/client.php
@@ -17,4 +17,4 @@ $arguments = array(
     'name' => $name
 );
 
-echo $client->do('python-hi', json_encode($arguments)).PHP_EOL;
+echo $client->doNormal('python-hi', json_encode($arguments)).PHP_EOL;


### PR DESCRIPTION
El método GearmanClient::do() es obsoleto desde pecl/gearman 1.0.0. Use GearmanClient::doNormal().
The GearmanClient::do() method is deprecated as of pecl/gearman 1.0.0. Use GearmanClient::doNormal().